### PR TITLE
Enabling support for detecting if the batcher is running in a background tab

### DIFF
--- a/addon/batcher.ts
+++ b/addon/batcher.ts
@@ -17,16 +17,16 @@ let running: boolean = false;
 let scheduleFnExecuted: boolean = false;
 
 const rafRace = (callback: Function) => {
-  setTimeout(() => {
+  let executeCallback = () => {
     if (!scheduleFnExecuted) {
+      scheduleFnExecuted = true;
       callback();
     }
-  }, 20);
+  };
 
-  return requestAnimationFrame(() => {
-    scheduleFnExecuted = true;
-    callback();
-  });
+  setTimeout(executeCallback, 20);
+
+  return requestAnimationFrame(executeCallback);
 };
 
 const scheduleFn: MaybeRequestAnimationFrame =
@@ -72,6 +72,7 @@ function run(): void {
       }
 
       running = false;
+      scheduleFnExecuted = false;
 
       if (mutations.length > 0 || reads.length > 0) {
         run();

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   },
   "lint-staged": {
     "package.json,{app,addon,config,tests}/**/*.{js,json}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "dependencies": {
+    "@glimmer/env": "^0.1.7",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-typescript": "^2.0.2",
     "ember-test-waiters": "^1.0.0"

--- a/tests/unit/batcher-test.ts
+++ b/tests/unit/batcher-test.ts
@@ -1,9 +1,16 @@
 import { module, test } from 'ember-qunit';
 import { settled } from '@ember/test-helpers';
 import { readDOM, mutateDOM } from 'ember-batcher';
+import { visibilityChange } from 'ember-batcher/batcher';
 import { getPendingWaiterState, ITestWaiterDebugInfo } from 'ember-test-waiters';
 
 module('Unit | Batcher', function() {
+  test('it errors on background tabs', function(assert: Assert) {
+    assert.throws(() => {
+      visibilityChange(true, () => true)();
+    });
+  });
+
   test('it runs reads', async function(assert: Assert) {
     assert.expect(3);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,6 +867,11 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
 
+"@glimmer/env@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
+  integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
+
 "@glimmer/interfaces@^0.41.4":
   version "0.41.4"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.41.4.tgz#3f3e26abea8a4e1463130e9a75e94372781d154b"


### PR DESCRIPTION
When running ember-batcher's `readDOM`/`mutateDOM` functions, there are two observed issues when the running tab is backgrounded:

- the `requestAnimationFrame` invocation will be throttled, being invoked non-deterministically. This can cause the user function passed to either of the above APIs to not execute, potentially causing breaking issues
- related to the above, the test waiters employed in this addon will not correctly invoke their `endAsync` methods, resulting in the test timing out.

This PR addresses these issues in the following ways:

- Adds a race between the `requestAnimationFrame` call and a `setTimeout`
	- if the raf completes, the setTimeout runs a noop
	- if the raf doesn't complete, the `setTimeout` falls back to invoking the user function
- binds to `visibilitychange` to detect when a tab is backgrounded when in dev or test mode, and throws an error indicating such to the user